### PR TITLE
Enhance GUI layout with side panel

### DIFF
--- a/jcontext/file_indexer.py
+++ b/jcontext/file_indexer.py
@@ -298,3 +298,10 @@ class FileIndexer:
         for paths in self.file_index.values():
             unique_paths.update(paths)
         return len(unique_paths)
+
+    def get_all_files(self) -> List[str]:
+        """Return a sorted list of all indexed file paths."""
+        unique_paths: Set[str] = set()
+        for paths in self.file_index.values():
+            unique_paths.update(paths)
+        return sorted(unique_paths)


### PR DESCRIPTION
## Summary
- add method to retrieve all indexed files
- align title with prompt label and move render toggle to button row
- replace history panel with notebook that includes a file tree tab
- remove project info section and update status updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a37917ab08330a75938c6fe1b59d7